### PR TITLE
[Death Knight] Updating DK resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
     <div class="tc-box" id="tc_death_knight_frost" style="display: none;" >
       <ul type="square">
         <li>Please use the trinket analysis of your spec's theorycrafters for more accuracy.</li>
-        <li>Theorycrafter resource: <a href="https://docs.google.com/document/d/1aVoO3dkG-YJGTU1E0xju-F178HBdILT_2rSMR3F1x4o" target="blank">Frost DK FAQ 7.2.5</a></li>
+        <li>Theorycrafter resource: <a href="https://goo.gl/gVBHCW" target="blank">Frost DK FAQ 7.3</a></li>
         <li>Discord: <a href="https://discord.gg/hq6HwSB" target="blank">Acherus</a></li>
       </ul>
     </div>
@@ -325,7 +325,7 @@
     <div class="tc-box" id="tc_death_knight_unholy" style="display: none;" >
       <ul type="square">
         <li>Please use the trinket analysis of your spec's theorycrafters for more accuracy.</li>
-        <li>Theorycrafter resource: <a href="http://www.wowhead.com/unholy-death-knight-guide" target="blank">Guide</a> / <a href="https://docs.google.com/spreadsheets/d/1efg3uitY4HDHjnBtUckq5RPJ1XyyZIzVbt52otMa8Uc/edit#gid=1479337307" target="blank">Trinkets</a> </li>
+        <li>Theorycrafter resource: <a href="https://goo.gl/SjcJ3n" target="blank">Guide</a> / <a href="https://docs.google.com/spreadsheets/d/1efg3uitY4HDHjnBtUckq5RPJ1XyyZIzVbt52otMa8Uc/edit#gid=1479337307" target="blank">Trinkets</a> </li>
         <li>Discord: <a href="https://discord.gg/hq6HwSB" target="blank">Acherus</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Changed the link to the frost FAQ (and unholy trinket link) to have the short URL we link in Acherus (same files) and changed the name to reflect the 7.3 update.
Changed the unholy guide link to the new Unholy guide. 