### PR TITLE
Missing translation for restoration shaman in pt added

### DIFF
--- a/translations/pt.json
+++ b/translations/pt.json
@@ -41,6 +41,7 @@
   "translate_subtlety": "Subterfúgio",
   "translate_elemental": "Elemental",
   "translate_enhancement": "Aperfeiçoamento",
+  "translate_restoration": "Restauração",
   "translate_affliction": "Suplicio",
   "translate_demonology": "Demonologia",
   "translate_destruction": "Destruição",


### PR DESCRIPTION
## File
> translations/en.json

## Issue / Problem
> When the selected language is set to portuguese, there is a missing translation for Shaman in the Restoration role

## Feature / Improvement
> Missing translation for Restoration Shaman added in pt.json
